### PR TITLE
Observe for artist name from DOM and pass to React component in Chrome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 secrets.*.js
+*.log

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,7 +1,0 @@
-chrome.runtime.onMessage.addListener(
-    function(request, sender, sendResponse){
-
-       localStorage["from"] = request.from;
-       localStorage["subject"] = request.subject;
-    }
-);

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -1,4 +1,96 @@
-chrome.runtime.sendMessage({
-  from:    'content',
-  subject: 'hello there'
-});
+/*
+  Content script does a bunch of work to scrape the artist name, update the Chrome extension,
+  and observe the DOM for if the artist name changes.
+
+  Thanks to javascript hoisting, the best way to understand this script is to read from top to bottom.
+*/
+
+/*
+  1. Wait for artist name node to appear in order for us to setup the observer on it
+
+  This uses a recursive requestAnimationFrame loop to keep checking the DOM for the node we want to
+  observe. Essentially, to make sure we're on the webpage that has the artist name selector. Later,
+  we may want to scope where this script is run better in the manifest.json settings.
+
+  We also run updateArtist to notify the Chrome extension the artist name as soon as it's detected.
+
+  There is timeout of 10000ms (10seconds) to avoid memory leaks.
+*/
+let raf;
+let startTime;
+
+function onArtistLoad(timestamp) {
+  if (!startTime) { startTime = timestamp}
+
+  if (!!queryObserverNode() && !!queryArtistName()) {
+    updateArtist(queryArtistName());
+    setupObserver();
+    window.cancelAnimationFrame(raf);
+
+  } else if (timestamp - startTime > 10000) {
+    window.cancelAnimationFrame(raf);
+
+  } else {
+    raf = window.requestAnimationFrame(onArtistLoad);
+  }
+}
+
+raf = window.requestAnimationFrame(onArtistLoad);
+
+/*
+  2. Continuously observes the artist name node for changes
+
+  The callback in MutationObserver is what fires when the node changes. In this case,
+  we only care when the artist name changes (ie: when the next song plays). That's when we
+  fire updateArtist to send an event to the Chrome extension.
+
+  In every callback, we disconnect and reconnect the observer to the latest observer node
+  so this will still fire for the next artist name change.
+*/
+function setupObserver() {
+  let artistName = queryArtistName();
+
+  const observer = new MutationObserver(() => {
+    let newArtistName = queryArtistName();
+
+    if (artistName !== newArtistName) {
+      artistName = newArtistName;
+      updateArtist(artistName);
+    }
+
+    observer.disconnect();
+    observer.observe(queryObserverNode(), observerConfig);
+  });
+
+  observer.observe(queryObserverNode(), observerConfig);
+}
+
+const ARTIST_NAME_SELECTOR = 'nowPlayingTopInfo__current__artistName';
+const OBSERVER_NODE_SELECTOR = 'nowPlayingTopInfo__current';
+const observerConfig = { attributes: true, childList: true, characterData: true };
+
+function queryArtistName() {
+  const node = document.getElementsByClassName(ARTIST_NAME_SELECTOR)[0];
+  return (node && node.text) ? node.text.trim() : null;
+}
+
+function queryObserverNode() {
+  return document.getElementsByClassName(OBSERVER_NODE_SELECTOR)[0];
+}
+
+/*
+  3. Set artist in Chrome's storage and send message to the popup page (see popup.js)
+
+  We set the artist on storage in case this function is called before the popup is opened.
+  A message sent to popup when it is not opened will be missed. Storing the artist instorage allows
+  the popup to still be able to find the latest artist.
+*/
+function updateArtist(artist) {
+  chrome.storage.sync.set({'artist': artist})
+
+  chrome.runtime.sendMessage({
+    sender: 'contentScript',
+    type: 'UPDATE_ARTIST',
+    artist,
+  });
+}

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -1,9 +1,36 @@
 import "../css/popup.css";
 import App from "./popup/app_component.jsx";
 import React from "react";
-import { render } from "react-dom";
+import { render, unmountComponentAtNode } from "react-dom";
 
-render(
-  <App artist="Tool" />,
-  window.document.getElementById("app-container")
-);
+const appContainerNode = window.document.getElementById("app-container");
+
+/*
+  When the popup is opened, the window "loads", and we grab the artist from Chrome storage.
+  We render the React component with the artist name.
+*/
+window.onload = () => {
+  chrome.storage.sync.get(['artist'], (items) => {
+    render(
+      <App artist={items.artist} />,
+      appContainerNode
+    );
+  });
+}
+
+/*
+  We continue to listen for messages to update the artist in case the artist name changes
+  while the popup is open.
+*/
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === "UPDATE_ARTIST") {
+    unmountComponentAtNode(appContainerNode);
+
+    render(
+      <App artist={msg.artist} />,
+      appContainerNode
+    );
+  }
+});
+
+

--- a/src/js/popup/app_component.jsx
+++ b/src/js/popup/app_component.jsx
@@ -16,7 +16,7 @@ import PropTypes from 'prop-types';
 }
 
 App.propTypes = {
-  artist: PropTypes.string.isRequired
+  artist: PropTypes.string
 }
 
 export default App;

--- a/src/js/popup/event_section_component.jsx
+++ b/src/js/popup/event_section_component.jsx
@@ -9,7 +9,7 @@ class EventSection extends Component {
     this.state = {
       artist: props.artist,
       events: [],
-      url: getSecretURL(props.artist) // this will hopefully change tomorrow ^^
+      url: getSecretURL(encodeURIComponent(props.artist)) // this will hopefully change tomorrow ^^
     };
   }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Chrome Extension Webpack",
+  "name": "Concerts Near You",
   "options_page": "options.html",
   "background": {
     "page": "background.html"
@@ -13,5 +13,8 @@
 
   }],
   "manifest_version": 2,
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
+  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "permissions": [
+    "storage"
+  ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,9 @@ var options = {
     background: path.join(__dirname, "src", "js", "background.js"),
     contentScript: path.join(__dirname, "src", "js", "contentScript.js")
   },
+  chromeExtensionBoilerplate: {
+    notHotReload: ["contentScript"]
+  },
   output: {
     path: path.join(__dirname, "build"),
     filename: "[name].bundle.js"


### PR DESCRIPTION
@Ticketfly/frontenders 

Implements:

* Observes artist name on Pandora
* Sends it to the Chrome extension popup
* Passes it to React component

Thought I'd just get this out ASAP so other people can work on whatever without being blocked. 

To do (in following PRs):

* Refactor the individual parts of `contentScript.js`
* Implement what happens when you leave a page with artist name and come back.
* Haven't really tested what happens when you start on a non-artist name page and go to an artist name page. Currently, there's a timeout after 10s if it doesn't find the artist name selector.
* Need more thought on clearing storage if we're on a page that has no artist name. Currently, the popup will show the "latest" artist set in storage.

It would really help development if we rendered some Not Found message in the React component if the artist doesn't return any events from the API.
